### PR TITLE
reliability: stabilize identity and harden service lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  shell-tests:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Install static analysis tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+      - name: Validate POSIX shell syntax
+        run: find . -type f -name '*.sh' -print0 | xargs -0 -n1 dash -n
+      - name: Run ShellCheck errors
+        run: find . -type f -name '*.sh' -print0 | xargs -0 shellcheck --severity=error --shell=sh
+      - name: Inspect systemd security exposure
+        run: systemd-analyze security --offline=yes systemd/leigod_plugin.service
+      - name: Run tests
+        run: |
+          for test_file in tests/test-*.sh; do
+            sh "$test_file"
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Source release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out tagged source
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        with:
+          fetch-depth: 0
+      - name: Verify version tag
+        run: |
+          . ./release.env
+          test "$GITHUB_REF_NAME" = "v$PACKAGE_VERSION"
+      - name: Build reproducible source archive
+        run: |
+          . ./release.env
+          archive="leigod-plugin-${PACKAGE_VERSION}-source.tar.gz"
+          git archive --format=tar --prefix="leigod-plugin-${PACKAGE_VERSION}/" "$GITHUB_SHA" | gzip -n > "$archive"
+          sha256sum "$archive" > SHA256SUMS
+      - name: Publish source-only release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          . ./release.env
+          gh release create "$GITHUB_REF_NAME" \
+            "leigod-plugin-${PACKAGE_VERSION}-source.tar.gz" SHA256SUMS \
+            --verify-tag --generate-notes \
+            --title "Leigod Plugin $PACKAGE_VERSION (source only)"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Leigod Plugin — SteamDeck 网络加速器 | 通用 Linux 移植版
 
-[雷神加速器](https://www.leigod.com) 的 SteamDeck 插件，伪装后可在 **x86_64 Linux 发行版**（Ubuntu / Debian / Fedora / Arch / openSUSE 等）上运行。伪装为 SteamDeck 硬件，通过手机 App 绑定后即可对游戏进行网络加速。
+[雷神加速器](https://www.leigod.com) 的 SteamDeck 插件兼容层，面向使用 systemd 的、
+可变更系统分区的 **x86_64 Linux**。通过外部环境模拟 SteamDeck 硬件后，可使用手机
+App 绑定并启动网络加速。
 
 ## 原理
 
@@ -8,19 +10,33 @@
 |------|------|
 | **硬件伪装** | systemd `BindReadOnlyPaths` 劫持 `/sys/class/dmi/id/product_name` → `Jupiter` |
 | **系统伪装** | 同上劫持 `/etc/os-release` → `SteamOS` |
-| **网卡伪装** | 创建 `dummy` 类型虚拟 `wlan0`，克隆物理网卡 MAC |
+| **网卡伪装** | 创建 `dummy` 类型虚拟 `wlan0`，使用持久化的本机专属 MAC |
 | **路径修复** | `/home/leigod` → `/opt/leigod` 符号链接 |
 | **进程管理** | systemd `KillMode=control-group` 确保重启时清理所有子进程 |
 
 > **本项目的技术定位：** 仅通过 systemd 的 `BindReadOnlyPaths` 和网络层配置（创建 dummy 接口）在**外部模拟** SteamDeck 运行环境。未对雷神核心二进制（`acc-gw.router.amd64`）进行任何逆向分析、修改或破解。
 
-## 系统要求
+## 系统要求与支持范围
 
-- **架构**: x86_64 (amd64)
-- **内核**: Linux（支持 `dummy`、`tun`、`iptables` 模块）
-- **init**: systemd v227+
-- **依赖**: `ipset`、`curl`，以及 `sha256sum` 或 `shasum`
-- **安装/构建时需要互联网连接**（自动从雷神服务器下载二进制）
+- **架构**：仅 x86_64（amd64）；
+- **init**：正在运行的 systemd 249 或更高版本；
+- **内核能力**：`dummy`、TUN（必须存在 `/dev/net/tun`）、netfilter/iptables；
+- **用户空间依赖**：`curl`、`ip`、`ipset`、`iptables`、`pgrep`、
+  `sha256sum`；安装脚本会按发行版安装对应软件包；
+- **网络**：安装或构建时需要连接雷神下载服务器。
+
+当前宿主机安装脚本只支持以下可变更系统：
+
+| 系列 | 包管理器 | 状态 |
+|---|---|---|
+| Debian / Ubuntu | `apt-get` | 支持 |
+| Fedora | `dnf` | 支持 |
+| Arch Linux | `pacman` | 支持 |
+| openSUSE | `zypper` | 支持 |
+
+Bazzite、Fedora Silverblue/Kinoite、CoreOS、bootc 等 Atomic/不可变发行版不支持
+直接运行本安装脚本。脚本会在修改系统前拒绝这些环境；建议使用独立的、可变更的
+Linux 系统或虚拟机。
 
 ## 快速安装
 
@@ -33,6 +49,10 @@ sudo ./install.sh
 安装脚本会下载雷神文件，在执行或安装前使用仓库固定的 SHA-256 进行校验。校验失败时安装会立即终止，原有已安装文件不会被替换。
 
 安装后打开手机雷神加速器 App → 绑定设备 → 开始加速。
+
+首次启动会根据 `/etc/machine-id` 生成一个本地管理、单播 MAC，并保存到
+`/var/lib/leigod/device-mac`。它不再复制 NetworkManager 可能随机化的物理网卡
+MAC，因此重启服务或重新安装后设备身份保持不变。
 
 ## 下载安全
 
@@ -59,8 +79,11 @@ leigod-plugin-linux/
 ├── install.sh                    # 通用安装脚本
 ├── uninstall.sh                  # 通用卸载脚本
 ├── checksums.sha256              # 固定的上游文件 SHA-256
+├── release.env                   # 版本与可复现构建时间戳
+├── THIRD_PARTY_NOTICES.md        # 第三方文件及许可边界
 ├── scripts/
-│   └── fetch-assets.sh           # 下载、校验与原子安装
+│   ├── fetch-assets.sh           # 下载、校验与原子安装
+│   └── device-mac.sh             # 生成并持久化设备 MAC
 ├── opt/leigod/
 │   ├── acc-gw.router.amd64       # 雷神加速主程序（下载时获取）
 │   ├── acc_upgrade_monitor       # 升级程序副本（默认不启动）
@@ -76,7 +99,9 @@ leigod-plugin-linux/
 │       └── ipdatacloud_country.xdb  # IP 地理位置数据库（下载时获取）
 ├── systemd/
 │   └── leigod_plugin.service     # systemd 服务单元
-├── debian/                       # dpkg-deb 打包文件
+├── debian/                       # dpkg-deb 元数据和维护脚本
+├── tests/                        # 自动测试
+├── .github/workflows/            # CI 与源码 Release 工作流
 └── packages/
     ├── build-deb.sh              # 构建 .deb 包
     └── build-tar.sh              # 构建 .tar.gz 包
@@ -91,6 +116,11 @@ sudo systemctl stop    leigod_plugin.service
 sudo journalctl -xeu   leigod_plugin.service
 ```
 
+监控脚本直接写入 journald，不再无限追加自己的日志文件。systemd 负责日志轮转；
+闭源程序需要的 `/tmp/acc` 位于 `PrivateTmp` 隔离空间、权限为 `0700`，其主日志默认
+超过 50 MiB 时截断。服务锁位于权限为 `0700` 的 `/run/leigod`，并通过原子目录
+创建；设备 MAC 位于 `/var/lib/leigod`，用于跨重装保持身份。
+
 ## 卸载
 
 ```bash
@@ -99,6 +129,12 @@ sudo ./uninstall.sh
 ```
 
 卸载脚本不会清空宿主机共享的 iptables 表。服务会先收到停止信号，以便核心程序清理其规则；如异常退出后网络状态仍有残留，安全做法是重启系统，不要执行 `iptables -t mangle -F`。
+
+默认卸载会保留 `/var/lib/leigod/device-mac`。如需同时清除绑定身份：
+
+```bash
+sudo LEIGOD_PURGE_STATE=1 ./uninstall.sh
+```
 
 ## 从零构建安装包
 
@@ -112,6 +148,13 @@ bash build-tar.sh
 
 构建产物输出到 `packages/` 目录。
 
+构建器使用固定的上游 SHA-256、统一文件时间戳、排序和数字所有者信息，确保相同
+源码及相同 `release.env` 可以生成相同产物。CI 会验证 Shell 语法、MAC 稳定性、
+下载篡改失败保护以及 TAR 包可复现性。
+
+带版本标签的 GitHub Actions Release 只发布可复现的**源码包**。包含雷神二进制的
+DEB/TAR 仅供本地构建；未取得权利人明确许可前，不应公开再分发。
+
 ## 常见问题
 
 **Q: 下载文件提示 SHA-256 mismatch？**  
@@ -121,7 +164,6 @@ bash build-tar.sh
 
 ```bash
 journalctl -xeu leigod_plugin.service
-tail -f /tmp/acc/log/acc_daemon.log
 ```
 
 **Q: 重启后加速失效？**  
@@ -131,13 +173,20 @@ tail -f /tmp/acc/log/acc_daemon.log
 不能。雷神官方只提供了 amd64 二进制。
 
 **Q: 更换网卡后绑定会丢失吗？**  
-MAC 地址回退到 `/etc/machine-id` 派生值，只要系统未重装则不变。绑定信息同时保存在雷神云端。
+虚拟 `wlan0` 使用 `/var/lib/leigod/device-mac` 中的持久 MAC，与物理网卡无关。
+如果系统本身已有名为 `wlan0` 的物理无线接口，脚本不会擅自修改它；绑定前需在
+NetworkManager 中为该连接关闭 MAC 随机化。Issue
+[#1](https://github.com/Husky0c/leigod-plugin-linux/issues/1) 记录了这一情况。
 
 ## 免责声明
 
 本仓库**不含**雷神官方二进制文件，也未对雷神核心程序进行任何逆向分析、修改或破解。所有脚本仅通过 systemd 的 `BindReadOnlyPaths` 和网络层配置（创建 dummy 接口）在**外部模拟** SteamDeck 运行环境，使未修改的雷神官方二进制在普通 PC 上正常运行。
 
-`acc-gw.router.amd64` 和 `ipdatacloud_country.xdb` 由安装/构建脚本下载并校验，版权归雷神所有。使用雷神服务需遵守其服务条款。
+`acc-gw.router.amd64` 和 `ipdatacloud_country.xdb` 由安装/构建脚本下载并校验，
+版权归雷神所有。仓库根目录 MIT License 只覆盖本项目原创代码，不覆盖雷神二进制、
+数据库、配置或上游衍生内容；具体边界见
+[`THIRD_PARTY_NOTICES.md`](THIRD_PARTY_NOTICES.md)。使用及再分发前需遵守雷神
+服务条款并取得必要授权。
 
 本项目仅供学习研究。请遵守当地法律法规。
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,25 @@
+# Third-party notices
+
+The repository-level MIT license applies only to code and documentation
+originally authored for this compatibility project.
+
+## Leigod material
+
+The following material is supplied by, derived from, or interoperates with the
+Leigod SteamDeck plugin and is **not relicensed under MIT**:
+
+- `acc-gw.router.amd64` (downloaded during installation/build);
+- `ipdatacloud_country.xdb` (downloaded during installation/build);
+- compatibility configuration under `opt/leigod/config/`;
+- SteamDeck plugin process behavior adapted by
+  `opt/leigod/steamdeck_acc_monitor.sh`.
+
+All rights in Leigod names, services, binaries, databases, configuration and
+upstream-derived material remain with their respective owners. No permission
+to redistribute those assets is granted by this repository.
+
+Before publishing a binary package or archive that embeds downloaded Leigod
+assets, obtain explicit redistribution permission from the relevant
+rightsholder. The project's automated GitHub Release contains source code only;
+end users download the official assets themselves and the installer verifies
+their pinned SHA-256 digests.

--- a/debian/control
+++ b/debian/control
@@ -1,11 +1,10 @@
 Package: leigod-plugin
-Version: 1.2.2.15
+Version: 1.2.2.15-1
 Section: net
 Priority: optional
 Architecture: amd64
-Depends: ipset, curl
+Depends: ca-certificates, curl, iproute2, ipset, iptables, procps, systemd (>= 249)
 Maintainer: Leigod Plugin Packager
-Description: Leigod network accelerator plugin (SteamDeck variant for Ubuntu)
- Modified to run on standard Ubuntu systems by spoofing SteamDeck
- hardware identification. Provides network acceleration for gaming
- via the Leigod mobile app.
+Description: Leigod network accelerator plugin compatibility package
+ Runs the unmodified SteamDeck accelerator on supported mutable,
+ systemd-based x86_64 Linux distributions.

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,60 +1,50 @@
 #!/bin/sh
-set -e
+set -eu
 
-BASE="/opt/leigod"
-SERVICE_FILE="/etc/systemd/system/leigod_plugin.service"
+BASE=/opt/leigod
+SERVICE_NAME=leigod_plugin.service
 
 case "$1" in
     configure)
+        [ -d /run/systemd/system ] || {
+            echo "[ERROR] A running systemd system instance is required" >&2
+            exit 1
+        }
+        [ -c /dev/net/tun ] || {
+            echo "[ERROR] /dev/net/tun is unavailable" >&2
+            exit 1
+        }
+
         if [ -d /home/leigod ] && [ ! -L /home/leigod ]; then
-            if rmdir /home/leigod 2>/dev/null; then
-                echo "Removed empty directory /home/leigod"
-            else
-                echo "Warning: /home/leigod is a non-empty directory. Please move it manually."
-            fi
+            rmdir /home/leigod 2>/dev/null || {
+                echo "[ERROR] /home/leigod is non-empty; move it before installing" >&2
+                exit 1
+            }
         fi
-
-        if [ ! -L /home/leigod ]; then
-            ln -sf "$BASE" /home/leigod
-            echo "Created symlink /home/leigod -> $BASE"
-        fi
-
-        cat > "$SERVICE_FILE" << 'EOF'
-[Unit]
-Description=Leigod Plugin Service
-Wants=network-online.target
-After=network.target network-online.target
-
-[Service]
-ExecStart=/opt/leigod/steamdeck_acc_monitor.sh
-KillMode=control-group
-Restart=always
-RestartSec=3
-BindReadOnlyPaths=/opt/leigod/fake_product_name:/sys/class/dmi/id/product_name
-BindReadOnlyPaths=/opt/leigod/fake_os-release:/etc/os-release
-
-[Install]
-WantedBy=default.target
-EOF
+        ln -sfn "$BASE" /home/leigod
 
         systemctl daemon-reload
-        systemctl enable leigod_plugin.service
-        systemctl start leigod_plugin.service
+        systemctl enable "$SERVICE_NAME"
+        systemctl restart "$SERVICE_NAME"
 
-        echo ""
-        echo "============================================"
-        echo " Leigod Plugin installed successfully!"
-        echo "============================================"
-        echo " Next steps:"
-        echo "   1. Open the Leigod mobile app"
-        echo "   2. Bind the device (scan QR code)"
-        echo "   3. Start acceleration"
-        echo ""
+        attempts=0
+        while [ "$attempts" -lt 25 ]; do
+            if systemctl is-active --quiet "$SERVICE_NAME" \
+                && pgrep -f '/opt/leigod/acc-gw\.router\.amd64.*-r daemon' >/dev/null 2>&1; then
+                echo "Leigod Plugin installed successfully."
+                exit 0
+            fi
+            systemctl is-failed --quiet "$SERVICE_NAME" && break
+            attempts=$((attempts + 1))
+            sleep 1
+        done
+
+        journalctl -u "$SERVICE_NAME" -n 40 --no-pager >&2 || true
+        echo "[ERROR] $SERVICE_NAME did not become healthy" >&2
+        exit 1
         ;;
-
     abort-upgrade|abort-remove|abort-deconfigure)
         ;;
-
     *)
         echo "postinst called with unknown argument: $1" >&2
         exit 1

--- a/debian/postrm
+++ b/debian/postrm
@@ -1,30 +1,23 @@
 #!/bin/sh
-set -e
+set -eu
 
 case "$1" in
     remove|abort-install|abort-upgrade|disappear)
-        rm -f /etc/systemd/system/leigod_plugin.service
         systemctl daemon-reload 2>/dev/null || true
-
-        if [ -L /home/leigod ] && [ "$(readlink /home/leigod)" = "/opt/leigod" ]; then
+        if [ -L /home/leigod ] && [ "$(readlink /home/leigod)" = /opt/leigod ]; then
             rm -f /home/leigod
         fi
+        rm -rf /run/leigod
         ;;
-
     purge)
-        if [ -L /home/leigod ] && [ "$(readlink /home/leigod)" = "/opt/leigod" ]; then
+        if [ -L /home/leigod ] && [ "$(readlink /home/leigod)" = /opt/leigod ]; then
             rm -f /home/leigod
         fi
-
-        rm -rf /tmp/acc
-
-        rm -f /etc/systemd/system/leigod_plugin.service
+        rm -rf /run/leigod /var/lib/leigod
         systemctl daemon-reload 2>/dev/null || true
         ;;
-
     upgrade|failed-upgrade)
         ;;
-
     *)
         echo "postrm called with unknown argument: $1" >&2
         exit 1

--- a/debian/preinst
+++ b/debian/preinst
@@ -1,15 +1,9 @@
 #!/bin/sh
-set -e
+set -eu
 
-if systemctl is-active --quiet leigod_plugin.service 2>/dev/null; then
+if command -v systemctl >/dev/null 2>&1 \
+    && systemctl cat leigod_plugin.service >/dev/null 2>&1; then
     systemctl stop leigod_plugin.service
 fi
-
-for proc in acc-gw.router.amd64 acc_upgrade_monitor steamdeck_acc_monitor.sh; do
-    pids=$(pidof "$proc" 2>/dev/null || true)
-    if [ -n "$pids" ]; then
-        kill -9 $pids 2>/dev/null || true
-    fi
-done
 
 exit 0

--- a/debian/prerm
+++ b/debian/prerm
@@ -1,20 +1,13 @@
 #!/bin/sh
-set -e
+set -eu
 
 case "$1" in
     remove|purge|upgrade|deconfigure)
-        if systemctl is-active --quiet leigod_plugin.service 2>/dev/null; then
+        if command -v systemctl >/dev/null 2>&1 \
+            && systemctl cat leigod_plugin.service >/dev/null 2>&1; then
             systemctl stop leigod_plugin.service
         fi
-
-        for proc in acc-gw.router.amd64 acc_upgrade_monitor steamdeck_acc_monitor.sh; do
-            pids=$(pidof "$proc" 2>/dev/null || true)
-            if [ -n "$pids" ]; then
-                kill -9 $pids 2>/dev/null || true
-            fi
-        done
         ;;
-
     *)
         echo "prerm called with unknown argument: $1" >&2
         exit 1

--- a/install.sh
+++ b/install.sh
@@ -1,52 +1,132 @@
 #!/bin/sh
-set -e
+set -eu
 
-VERSION="1.2.2.15"
-BASE="/opt/leigod"
-SERVICE_FILE="/etc/systemd/system/leigod_plugin.service"
-SCRIPT_DIR="$(CDPATH= cd -P "$(dirname "$0")" && pwd)"
+umask 022
 
-RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
-info()  { printf "${GREEN}[INFO]${NC} %s\n" "$*"; }
-warn()  { printf "${YELLOW}[WARN]${NC} %s\n" "$*"; }
-error() { printf "${RED}[ERROR]${NC} %s\n" "$*"; exit 1; }
+BASE=/opt/leigod
+SERVICE_NAME=leigod_plugin.service
+SERVICE_FILE=/etc/systemd/system/$SERVICE_NAME
+SCRIPT_DIR=$(CDPATH= cd -P "$(dirname "$0")" && pwd)
+SERVICE_WAS_ACTIVE=0
+INSTALL_COMPLETE=0
 
-if [ "$(id -u)" -ne 0 ]; then error "Please run as root (sudo ./install.sh)"; fi
+[ -r "$SCRIPT_DIR/release.env" ] || {
+    echo "[ERROR] Missing release.env" >&2
+    exit 1
+}
+# shellcheck disable=SC1091
+. "$SCRIPT_DIR/release.env"
+VERSION=$PACKAGE_VERSION
 
-ARCH=$(uname -m)
-if [ "$ARCH" != "x86_64" ]; then error "Only x86_64 supported, current: $ARCH"; fi
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
 
-if ! command -v systemctl >/dev/null 2>&1; then
-    error "systemd not found. This package requires systemd."
-fi
+info() {
+    printf '%b[INFO]%b %s\n' "$GREEN" "$NC" "$*"
+}
 
-detect_pkg_manager() {
-    if command -v apt >/dev/null 2>&1; then
-        PKG_MANAGER="apt"; PKG_INSTALL="apt install -y"; PKG_UPDATE="apt update"
+warn() {
+    printf '%b[WARN]%b %s\n' "$YELLOW" "$NC" "$*" >&2
+}
+
+error() {
+    printf '%b[ERROR]%b %s\n' "$RED" "$NC" "$*" >&2
+    exit 1
+}
+
+restore_previous_service() {
+    status=$?
+    trap - 0
+    if [ "$status" -ne 0 ] && [ "$INSTALL_COMPLETE" -eq 0 ] \
+        && [ "$SERVICE_WAS_ACTIVE" -eq 1 ]; then
+        warn "Installation failed; attempting to restart the previously active service"
+        systemctl restart "$SERVICE_NAME" 2>/dev/null || \
+            warn "Previous service could not be restarted; inspect it with systemctl status"
+    fi
+    exit "$status"
+}
+
+trap restore_previous_service 0
+trap 'exit 1' HUP INT TERM
+
+[ "$(id -u)" -eq 0 ] || error "Please run as root (sudo ./install.sh)"
+[ "$(uname -m)" = x86_64 ] || error "Only x86_64 is supported; current: $(uname -m)"
+command -v systemctl >/dev/null 2>&1 || error "systemctl is required"
+[ -d /run/systemd/system ] || error "A running systemd system instance is required"
+
+detect_platform() {
+    ID=
+    ID_LIKE=
+    VARIANT_ID=
+    IMAGE_ID=
+    [ ! -r /etc/os-release ] || . /etc/os-release
+
+    platform_words="$ID $ID_LIKE $VARIANT_ID $IMAGE_ID"
+    case "$platform_words" in
+        *bazzite*|*silverblue*|*kinoite*|*sericea*|*coreos*|*bootc*)
+            error "Atomic/immutable distributions are not supported by this host installer: $platform_words"
+            ;;
+    esac
+
+    if command -v apt-get >/dev/null 2>&1; then
+        PKG_MANAGER=apt
     elif command -v dnf >/dev/null 2>&1; then
-        PKG_MANAGER="dnf"; PKG_INSTALL="dnf install -y"; PKG_UPDATE="dnf check-update || true"
-    elif command -v yum >/dev/null 2>&1; then
-        PKG_MANAGER="yum"; PKG_INSTALL="yum install -y"; PKG_UPDATE="yum makecache"
-    elif command -v zypper >/dev/null 2>&1; then
-        PKG_MANAGER="zypper"; PKG_INSTALL="zypper install -y"; PKG_UPDATE="zypper refresh"
+        PKG_MANAGER=dnf
     elif command -v pacman >/dev/null 2>&1; then
-        PKG_MANAGER="pacman"; PKG_INSTALL="pacman -S --noconfirm"; PKG_UPDATE="pacman -Sy"
-    elif command -v apk >/dev/null 2>&1; then
-        PKG_MANAGER="apk"; PKG_INSTALL="apk add"; PKG_UPDATE="apk update"
+        PKG_MANAGER=pacman
+    elif command -v zypper >/dev/null 2>&1; then
+        PKG_MANAGER=zypper
     else
-        warn "Cannot detect package manager. Please manually install: ipset curl"
-        PKG_MANAGER="manual"
+        error "Supported package managers: apt-get, dnf, pacman, zypper"
     fi
     info "Detected package manager: $PKG_MANAGER"
 }
 
 install_deps() {
-    if [ "$PKG_MANAGER" = "manual" ]; then return; fi
-    info "Updating package lists..."
-    $PKG_UPDATE >/dev/null 2>&1 || true
-    info "Installing dependencies: ipset curl..."
-    $PKG_INSTALL ipset curl >/dev/null 2>&1 || error "Failed to install dependencies"
-    info "Dependencies installed."
+    info "Installing runtime dependencies..."
+    case "$PKG_MANAGER" in
+        apt)
+            apt-get update
+            apt-get install -y --no-install-recommends \
+                ca-certificates curl iproute2 ipset iptables procps
+            ;;
+        dnf)
+            dnf install -y \
+                ca-certificates curl iproute ipset iptables procps-ng
+            ;;
+        pacman)
+            pacman -S --noconfirm --needed \
+                ca-certificates curl iproute2 ipset iptables procps-ng
+            ;;
+        zypper)
+            zypper --non-interactive refresh
+            zypper --non-interactive install \
+                ca-certificates curl iproute2 ipset iptables procps
+            ;;
+    esac
+}
+
+verify_runtime() {
+    missing=
+    for command_name in curl grep ip ipset iptables pgrep sha256sum systemctl; do
+        if ! command -v "$command_name" >/dev/null 2>&1; then
+            missing="$missing $command_name"
+        fi
+    done
+    [ -z "$missing" ] || error "Missing required commands:$missing"
+    [ -c /dev/net/tun ] || error "/dev/net/tun is unavailable; load the tun module before installing"
+}
+
+stop_existing_service() {
+    if systemctl cat "$SERVICE_NAME" >/dev/null 2>&1; then
+        if systemctl is-active --quiet "$SERVICE_NAME"; then
+            SERVICE_WAS_ACTIVE=1
+        fi
+        info "Stopping the existing service before replacing files..."
+        systemctl stop "$SERVICE_NAME" || error "Failed to stop the existing service"
+    fi
 }
 
 download_binaries() {
@@ -67,27 +147,19 @@ download_binaries() {
         || error "Failed to fetch or verify Leigod assets"
 }
 
-stop_existing_service() {
-    if systemctl is-active --quiet leigod_plugin.service 2>/dev/null; then
-        info "Stopping existing Leigod service before replacing files..."
-        systemctl stop leigod_plugin.service \
-            || error "Failed to stop existing Leigod service"
-    fi
-}
-
 install_files() {
     info "Installing files to $BASE..."
-    mkdir -p "$BASE/config"
-    cp "$SCRIPT_DIR/opt/leigod/steamdeck_acc_monitor.sh" "$BASE/"
-    cp "$SCRIPT_DIR/opt/leigod/leigod_uninstall.sh" "$BASE/"
-    cp "$SCRIPT_DIR/opt/leigod/fake_os-release" "$BASE/"
-    cp "$SCRIPT_DIR/opt/leigod/fake_product_name" "$BASE/"
-    cp "$SCRIPT_DIR/opt/leigod/config/acc_version.ini" "$BASE/config/"
-    cp "$SCRIPT_DIR/opt/leigod/config/accelerator.ini" "$BASE/config/"
-    cp "$SCRIPT_DIR/opt/leigod/config/new_upgrade_conf.json" "$BASE/config/"
+    install -d -m 0755 "$BASE/config"
+    install -m 0755 "$SCRIPT_DIR/opt/leigod/steamdeck_acc_monitor.sh" "$BASE/"
+    install -m 0755 "$SCRIPT_DIR/opt/leigod/leigod_uninstall.sh" "$BASE/"
+    install -m 0755 "$SCRIPT_DIR/scripts/device-mac.sh" "$BASE/"
+    install -m 0644 "$SCRIPT_DIR/opt/leigod/fake_os-release" "$BASE/"
+    install -m 0644 "$SCRIPT_DIR/opt/leigod/fake_product_name" "$BASE/"
+    install -m 0644 "$SCRIPT_DIR/opt/leigod/config/acc_version.ini" "$BASE/config/"
+    install -m 0644 "$SCRIPT_DIR/opt/leigod/config/accelerator.ini" "$BASE/config/"
+    install -m 0644 "$SCRIPT_DIR/opt/leigod/config/new_upgrade_conf.json" "$BASE/config/"
     : > "$BASE/config/accelerator"
-    chmod 755 "$BASE/steamdeck_acc_monitor.sh" "$BASE/leigod_uninstall.sh"
-    info "Files installed."
+    chmod 0644 "$BASE/config/accelerator"
 }
 
 create_symlink() {
@@ -95,49 +167,42 @@ create_symlink() {
         if rmdir /home/leigod 2>/dev/null; then
             info "Removed empty directory /home/leigod"
         else
-            warn "/home/leigod is a non-empty directory. Please move it manually."
+            error "/home/leigod is a non-empty directory; move it before installing"
         fi
     fi
-    if [ ! -L /home/leigod ]; then
-        ln -sf "$BASE" /home/leigod
-        info "Created symlink /home/leigod -> $BASE"
-    fi
+    ln -sfn "$BASE" /home/leigod
 }
 
 setup_service() {
-    info "Creating systemd service..."
-    cat > "$SERVICE_FILE" << 'SERVICEEOF'
-[Unit]
-Description=Leigod Plugin Service
-Wants=network-online.target
-After=network.target network-online.target
-
-[Service]
-ExecStart=/opt/leigod/steamdeck_acc_monitor.sh
-KillMode=control-group
-Restart=always
-RestartSec=3
-BindReadOnlyPaths=/opt/leigod/fake_product_name:/sys/class/dmi/id/product_name
-BindReadOnlyPaths=/opt/leigod/fake_os-release:/etc/os-release
-
-[Install]
-WantedBy=default.target
-SERVICEEOF
+    info "Installing the hardened systemd service..."
+    install -m 0644 "$SCRIPT_DIR/systemd/leigod_plugin.service" "$SERVICE_FILE"
     systemctl daemon-reload
-    systemctl enable leigod_plugin.service
-    info "Service enabled (will auto-start on boot)."
+    systemctl enable "$SERVICE_NAME"
+}
+
+main_daemon_running() {
+    pgrep -f '/opt/leigod/acc-gw\.router\.amd64.*-r daemon' >/dev/null 2>&1
 }
 
 start_service() {
     info "Starting Leigod Plugin Service..."
-    systemctl restart leigod_plugin.service \
-        || error "Failed to start Leigod Plugin Service"
-    sleep 2
-    if systemctl is-active --quiet leigod_plugin.service; then
-        info "Service is running."
-    else
-        warn "Service is not running. Check: systemctl status leigod_plugin.service"
-    fi
+    systemctl restart "$SERVICE_NAME" || error "Failed to start $SERVICE_NAME"
+
+    attempts=0
+    while [ "$attempts" -lt 25 ]; do
+        if systemctl is-active --quiet "$SERVICE_NAME" && main_daemon_running; then
+            info "Service and acceleration daemon are running."
+            return 0
+        fi
+        if systemctl is-failed --quiet "$SERVICE_NAME"; then
+            break
+        fi
+        attempts=$((attempts + 1))
+        sleep 1
+    done
+
+    journalctl -u "$SERVICE_NAME" -n 40 --no-pager >&2 || true
+    error "$SERVICE_NAME did not become healthy; installation is incomplete"
 }
 
 print_summary() {
@@ -145,16 +210,25 @@ print_summary() {
     echo "============================================"
     echo " Leigod Plugin v$VERSION installed!"
     echo "============================================"
-    echo ""
-    echo " Next steps:"
-    echo "   1. Open the Leigod mobile app"
-    echo "   2. Bind the device (scan QR code)"
-    echo "   3. Start acceleration"
-    echo ""
-    echo " Manage: systemctl {status|restart|stop} leigod_plugin.service"
-    echo " Uninstall: sudo ./uninstall.sh"
+    echo " Device MAC: $(cat /var/lib/leigod/device-mac 2>/dev/null || echo pending)"
+    echo " Manage: systemctl {status|restart|stop} $SERVICE_NAME"
+    echo " Logs:   journalctl -u $SERVICE_NAME"
     echo ""
 }
 
-echo ""; echo "Leigod Plugin v$VERSION Installer"; echo "============================================"; echo ""
-detect_pkg_manager; install_deps; stop_existing_service; install_files; download_binaries; create_symlink; setup_service; start_service; print_summary
+echo ""
+echo "Leigod Plugin v$VERSION Installer"
+echo "============================================"
+echo ""
+
+detect_platform
+install_deps
+verify_runtime
+stop_existing_service
+download_binaries
+install_files
+create_symlink
+setup_service
+start_service
+INSTALL_COMPLETE=1
+print_summary

--- a/opt/leigod/leigod_uninstall.sh
+++ b/opt/leigod/leigod_uninstall.sh
@@ -1,47 +1,73 @@
 #!/bin/sh
 set -eu
 
-BASE="/opt/leigod"
-SERVICE_NAME="leigod_plugin.service"
-SERVICE_FILE="/etc/systemd/system/$SERVICE_NAME"
+BASE=/opt/leigod
+STATE_DIR=/var/lib/leigod
+RUNTIME_DIR=/run/leigod
+SERVICE_NAME=leigod_plugin.service
+SERVICE_FILE=/etc/systemd/system/$SERVICE_NAME
 
-info() { printf '[INFO] %s\n' "$*"; }
-warn() { printf '[WARN] %s\n' "$*" >&2; }
+info() {
+    printf '[INFO] %s\n' "$*"
+}
 
-if [ "$(id -u)" -ne 0 ]; then
+warn() {
+    printf '[WARN] %s\n' "$*" >&2
+}
+
+[ "$(id -u)" -eq 0 ] || {
     echo "[ERROR] Please run as root" >&2
     exit 1
-fi
+}
 
-info "Stopping Leigod service..."
-systemctl stop "$SERVICE_NAME" 2>/dev/null || true
-systemctl disable "$SERVICE_NAME" 2>/dev/null || true
-rm -f "$SERVICE_FILE"
-systemctl daemon-reload 2>/dev/null || true
+remove_managed_dummy() {
+    [ -r "$STATE_DIR/device-mac" ] || return 0
+    command -v ip >/dev/null 2>&1 || return 0
+    ip -d link show wlan0 2>/dev/null | grep -qw dummy || return 0
 
-# Kill only exact Leigod process names if the service did not stop them.
-if command -v pidof >/dev/null 2>&1; then
-    for process_name in acc-gw.router.amd64 acc_upgrade_monitor steamdeck_acc_monitor.sh; do
-        for pid in $(pidof "$process_name" 2>/dev/null || true); do
+    expected=$(tr 'A-F' 'a-f' < "$STATE_DIR/device-mac" | tr -d ' \t\r\n')
+    actual=$(cat /sys/class/net/wlan0/address 2>/dev/null || true)
+    if [ -n "$expected" ] && [ "$actual" = "$expected" ]; then
+        ip link delete wlan0 2>/dev/null || warn "Unable to remove managed dummy wlan0"
+    fi
+}
+
+stop_remaining_processes() {
+    command -v pgrep >/dev/null 2>&1 || return 0
+    for pattern in \
+        '/opt/leigod/acc-gw\.router\.amd64' \
+        '/opt/leigod/acc_upgrade_monitor' \
+        '/opt/leigod/steamdeck_acc_monitor\.sh'; do
+        for pid in $(pgrep -f "$pattern" 2>/dev/null || true); do
             case "$pid" in
                 ''|*[!0-9]*) continue ;;
             esac
-            kill "$pid" 2>/dev/null || true
+            [ "$pid" = "$$" ] || kill "$pid" 2>/dev/null || true
         done
     done
-fi
+}
 
-rm -rf "$BASE" /tmp/acc
-rm -f /var/run/acc_daemon.lock
+info "Stopping Leigod service..."
+systemctl stop "$SERVICE_NAME" 2>/dev/null || warn "Service stop returned an error"
+systemctl disable "$SERVICE_NAME" 2>/dev/null || true
+stop_remaining_processes
+remove_managed_dummy
+
+rm -f "$SERVICE_FILE"
+systemctl daemon-reload 2>/dev/null || true
+rm -rf "$BASE" "$RUNTIME_DIR"
 
 if [ -L /home/leigod ] && [ "$(readlink /home/leigod)" = "$BASE" ]; then
     rm -f /home/leigod
 fi
 
-# Never flush a shared host firewall table. The old upstream-derived script
-# used `iptables -t mangle -F`, which could delete unrelated Docker, VPN, and
-# firewall rules. The service is stopped gracefully so the Leigod process can
-# remove its own transient rules. A reboot is the safe fallback for stale rules.
+if [ "${LEIGOD_PURGE_STATE:-0}" = 1 ]; then
+    rm -rf "$STATE_DIR"
+    info "Persistent device identity removed."
+else
+    info "Preserved $STATE_DIR/device-mac for stable identity after reinstall."
+fi
+
 warn "Host firewall tables were intentionally left untouched."
 warn "If networking remains altered, reboot instead of flushing the mangle table."
 info "Leigod Plugin uninstalled."

--- a/opt/leigod/steamdeck_acc_monitor.sh
+++ b/opt/leigod/steamdeck_acc_monitor.sh
@@ -1,186 +1,189 @@
 #!/bin/sh
+set -u
 
-# 通用进程守护脚本
-# 默认只监控加速主进程。闭源自动升级进程默认禁用，避免绕过仓库中固定的
-# SHA-256 校验。确有需要时可显式设置 LEIGOD_ENABLE_UPDATER=1。
+umask 077
 
-run_env=$1
+BASE_PATH=/opt/leigod
+RUNTIME_DIR=${LEIGOD_RUNTIME_DIR:-/run/leigod}
+LOCK_DIR=$RUNTIME_DIR/monitor.lock
+ACC_TMP_DIR=${LEIGOD_ACC_TMP_DIR:-/tmp/acc}
+UPGRADE_FLAG=$ACC_TMP_DIR/upgrade_flag
+MAX_START_FAILURES=${LEIGOD_MAX_START_FAILURES:-3}
+MAX_DAEMON_LOG_BYTES=${LEIGOD_MAX_DAEMON_LOG_BYTES:-52428800}
+run_env=${1:-}
 
-# 日志目录配置
-LOG_DIR="/tmp/acc/log/"
-LOG_FILE="$LOG_DIR/steamdeck_acc_monitor.log"
-
-UPGRADE_FLAG="/tmp/acc/upgrade_flag"
-
-# 创建日志目录（如果不存在）
-mkdir -p "$LOG_DIR"
-
-# 日志函数
 log_message() {
-    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" >> "$LOG_FILE"
+    printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*"
 }
 
-# 初始化日志
-echo "=========================================" >> "$LOG_FILE"
-echo "[$(date '+%Y-%m-%d %H:%M:%S')] Starting process monitor daemon" >> "$LOG_FILE"
-echo "=========================================" >> "$LOG_FILE"
-
-# 获取架构
-arch=$(uname -m)
-if [ "${arch}" = "x86_64" ]; then
-    log_message "match x86_64 -> amd64"
-    arch="amd64"
-elif [ "${arch}" = "aarch64" ]; then
-    log_message "match aarch64 -> arm64"
-    arch="arm64"
-elif [ "${arch}" = "mips" ]; then
-    log_message "match mips -> mipsel"
-    arch="mipsel"
-elif [ "${arch}" = "armv7l" ]; then
-    log_message "match armv7l -> arm"
-    arch="arm"
-else
-    log_message "current arch not support, arch: ${arch}"
-    exit 1
-fi
-
-# 获取 Steam Deck 安装目录
-get_steamdeck_party() {
-    BASE_PATH="/opt/leigod"
-    log_message "steamdeck plugin install directory is $BASE_PATH"
-}
-
-# 调用函数获取安装目录
-get_steamdeck_party
-
-# 创建虚拟 wlan0 网卡（雷神需要它来获取设备号）
-if ! ip link show wlan0 >/dev/null 2>&1; then
-    # 获取真实物理网卡的固定 MAC 地址
-    REAL_MAC=""
-    for iface in wlp0s20f3 wlan0 eno2 eno1 ens32 ens33 ens34 ens35 ens36; do
-        if [ -f "/sys/class/net/${iface}/address" ]; then
-            REAL_MAC=$(cat "/sys/class/net/${iface}/address" 2>/dev/null)
-            [ -n "$REAL_MAC" ] && break
-        fi
-    done
-    # 如果都没找到，生成一个基于机器 ID 的固定 MAC
-    if [ -z "$REAL_MAC" ]; then
-        REAL_MAC="02:$(cat /etc/machine-id 2>/dev/null | md5sum | head -c 10 | sed 's/\(..\)/\1:/g;s/:$//')"
+cleanup() {
+    if [ -r "$LOCK_DIR/pid" ] && [ "$(cat "$LOCK_DIR/pid" 2>/dev/null)" = "$$" ]; then
+        rm -rf "$LOCK_DIR"
     fi
-    ip link add wlan0 type dummy
-    ip link set wlan0 address "$REAL_MAC"
-    ip link set wlan0 up
-    log_message "Created dummy wlan0 with MAC: $REAL_MAC"
-fi
+}
 
-# 单例锁文件路径（防止重复运行）
-LOCK_FILE="/var/run/acc_daemon.lock"
+trap cleanup 0
+trap 'exit 0' HUP INT TERM
 
-# 守护的进程列表
-# 格式：进程名:匹配参数:启动命令
-if [ "${run_env}" = "test" ]; then
-    PROCESS_DATA="
-    acc-gw.router.${arch}:-d debug -r daemon:${BASE_PATH}/acc-gw.router.${arch} -d debug -r daemon -m tun -p 5588
-    "
-    UPGRADE_PROCESS_DATA="
-    acc_upgrade_monitor:-d debug -r upgrade:${BASE_PATH}/acc_upgrade_monitor -d debug -r upgrade
-    "
-else
-    PROCESS_DATA="
-    acc-gw.router.${arch}:-r daemon:${BASE_PATH}/acc-gw.router.${arch} -r daemon -m tun -p 5588
-    "
-    UPGRADE_PROCESS_DATA="
-    acc_upgrade_monitor:-r upgrade:${BASE_PATH}/acc_upgrade_monitor -r upgrade
-    "
-fi
-
-if [ "${LEIGOD_ENABLE_UPDATER:-0}" = "1" ]; then
-    PROCESS_DATA="${PROCESS_DATA}${UPGRADE_PROCESS_DATA}"
-    log_message "WARNING: automatic upstream updater enabled; downloaded updates are not verified by checksums.sha256"
-else
-    log_message "Automatic upstream updater disabled; update through the verified installer"
-fi
-
-# 检查是否已有实例在运行
-if [ -f "$LOCK_FILE" ]; then
-    if kill -0 "$(cat "$LOCK_FILE")" 2>/dev/null; then
-        log_message "[Monitor] Daemon is already running (PID: $(cat "$LOCK_FILE")). Exiting."
+case $(uname -m) in
+    x86_64) arch=amd64 ;;
+    *)
+        log_message "Unsupported architecture: $(uname -m)"
         exit 1
-    else
-        # 锁文件存在但进程已死，清理锁文件
-        log_message "[Monitor] Removing stale lock file"
-        rm -f "$LOCK_FILE"
-    fi
-fi
+        ;;
+esac
 
-# 创建锁文件（写入当前PID）
-echo $$ > "$LOCK_FILE"
+mkdir -p "$RUNTIME_DIR"
+chmod 0700 "$RUNTIME_DIR"
+mkdir -p "$ACC_TMP_DIR/log"
+chmod 0700 "$ACC_TMP_DIR" "$ACC_TMP_DIR/log"
 
-# 检查进程是否存在（精确匹配参数）
-is_process_running() {
-    process_name="$1"
-    pattern="$2"
-
-    # 使用 pidof 获取进程PID
-    pids=$(pidof "$process_name" 2>/dev/null)
-    if [ -z "$pids" ]; then
-        return 1
-    fi
-
-    # 遍历所有PID，检查命令行参数是否匹配
-    for pid in $pids; do
-        if [ -f "/proc/$pid/cmdline" ]; then
-            # 读取进程命令行，将 \0 替换为空格
-            cmdline=$(tr '\0' ' ' < "/proc/$pid/cmdline")
-            if echo "$cmdline" | grep -qF -- "$pattern"; then
-                return 0
+if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+    old_pid=
+    [ ! -r "$LOCK_DIR/pid" ] || old_pid=$(cat "$LOCK_DIR/pid" 2>/dev/null)
+    case "$old_pid" in
+        ''|*[!0-9]*) ;;
+        *)
+            if kill -0 "$old_pid" 2>/dev/null; then
+                log_message "Monitor is already running with PID $old_pid"
+                exit 1
             fi
+            ;;
+    esac
+    rm -rf "$LOCK_DIR"
+    mkdir "$LOCK_DIR" 2>/dev/null || {
+        log_message "Unable to acquire monitor lock"
+        exit 1
+    }
+fi
+printf '%s\n' "$$" > "$LOCK_DIR/pid"
+
+DEVICE_MAC=$(LEIGOD_STATE_DIR=${LEIGOD_STATE_DIR:-/var/lib/leigod} \
+    "$BASE_PATH/device-mac.sh") || exit 1
+
+setup_wlan0() {
+    if ! ip link show wlan0 >/dev/null 2>&1; then
+        ip link add wlan0 type dummy || {
+            log_message "Unable to create dummy wlan0; check dummy kernel support and CAP_NET_ADMIN"
+            return 1
+        }
+    elif ! ip -d link show wlan0 2>/dev/null | grep -qw dummy; then
+        log_message "Existing wlan0 is a physical interface; its MAC is managed externally"
+        log_message "Disable NetworkManager MAC randomization before binding (see README)"
+        return 0
+    fi
+
+    current_mac=$(cat /sys/class/net/wlan0/address 2>/dev/null || true)
+    if [ "$current_mac" != "$DEVICE_MAC" ]; then
+        ip link set wlan0 down || return 1
+        ip link set wlan0 address "$DEVICE_MAC" || return 1
+    fi
+    ip link set wlan0 up || return 1
+    log_message "Stable dummy wlan0 ready with MAC $DEVICE_MAC"
+}
+
+setup_wlan0 || exit 1
+
+is_process_running() {
+    process_name=$1
+    pattern=$2
+    pids=$(pgrep -f "$process_name" 2>/dev/null || true)
+    [ -n "$pids" ] || return 1
+
+    for pid in $pids; do
+        case "$pid" in
+            ''|*[!0-9]*) continue ;;
+        esac
+        if [ -r "/proc/$pid/cmdline" ]; then
+            cmdline=$(tr '\0' ' ' < "/proc/$pid/cmdline")
+            case "$cmdline" in
+                *"$pattern"*) return 0 ;;
+            esac
         fi
     done
     return 1
 }
 
-log_message "Monitor daemon started (PID: $$)"
-log_message "Monitoring processes:"
+start_main_daemon() {
+    if [ "$run_env" = "test" ]; then
+        "$BASE_PATH/acc-gw.router.$arch" -d debug -r daemon -m tun -p 5588 \
+            >/dev/null 2>&1 </dev/null &
+    else
+        "$BASE_PATH/acc-gw.router.$arch" -r daemon -m tun -p 5588 \
+            >/dev/null 2>&1 </dev/null &
+    fi
+    sleep 2
+    is_process_running "acc-gw.router.$arch" "-r daemon"
+}
 
-# 主循环
-while true; do
-    # 判断是否正在升级，如果在升级则退出，由 systemd 按策略处理
+start_updater() {
+    if [ "$run_env" = "test" ]; then
+        "$BASE_PATH/acc_upgrade_monitor" -d debug -r upgrade \
+            >/dev/null 2>&1 </dev/null &
+    else
+        "$BASE_PATH/acc_upgrade_monitor" -r upgrade \
+            >/dev/null 2>&1 </dev/null &
+    fi
+}
+
+case "$MAX_START_FAILURES" in
+    ''|*[!0-9]*|0) MAX_START_FAILURES=3 ;;
+esac
+case "$MAX_DAEMON_LOG_BYTES" in
+    ''|*[!0-9]*|0) MAX_DAEMON_LOG_BYTES=52428800 ;;
+esac
+
+truncate_oversized_daemon_log() {
+    daemon_log=$ACC_TMP_DIR/log/acc_daemon.log
+    [ -f "$daemon_log" ] || return 0
+    log_size=$(wc -c < "$daemon_log" 2>/dev/null || echo 0)
+    case "$log_size" in
+        ''|*[!0-9]*) return 0 ;;
+    esac
+    if [ "$log_size" -gt "$MAX_DAEMON_LOG_BYTES" ]; then
+        : > "$daemon_log"
+        log_message "Truncated daemon log after it exceeded $MAX_DAEMON_LOG_BYTES bytes"
+    fi
+}
+
+failures=0
+updater_notice_written=0
+log_message "Monitor started with PID $$"
+log_message "Persistent device MAC: $DEVICE_MAC"
+
+while :; do
     if [ -f "$UPGRADE_FLAG" ]; then
-        log_message "Upgrade flag detected; monitor exiting"
+        log_message "Upgrade flag detected; exiting cleanly"
         exit 0
     fi
 
-    echo "$PROCESS_DATA" | while IFS=":" read -r process_name pattern start_cmd; do
-        # 跳过空行或空白行
-        [ -z "$(echo "$process_name" | tr -d " ")" ] && continue
-
-        # 去除可能的空格
-        process_name=$(echo "$process_name" | xargs)
-        pattern=$(echo "$pattern" | xargs)
-        start_cmd=$(echo "$start_cmd" | xargs)
-
-        # 检查进程是否存在
-        if ! is_process_running "$process_name" "$pattern"; then
-            log_message "Process not running: $process_name, starting..."
-            log_message "Start command: $start_cmd"
-
-            # 命令内容由上面的静态 PROCESS_DATA 构造，不接受外部输入。
-            # shellcheck disable=SC2086
-            $start_cmd >/dev/null 2>&1 </dev/null &
-
-            # 短暂等待，让进程启动
-            sleep 1
-
-            # 验证进程是否成功启动
-            if is_process_running "$process_name" "$pattern"; then
-                log_message "Successfully started: $process_name"
-            else
-                log_message "Failed to start: $process_name"
+    if is_process_running "acc-gw.router.$arch" "-r daemon"; then
+        failures=0
+    else
+        log_message "Main daemon is not running; starting it"
+        if start_main_daemon; then
+            failures=0
+            log_message "Main daemon started successfully"
+        else
+            failures=$((failures + 1))
+            log_message "Main daemon start failed ($failures/$MAX_START_FAILURES)"
+            if [ "$failures" -ge "$MAX_START_FAILURES" ]; then
+                log_message "Giving up so systemd can report and rate-limit the failure"
+                exit 1
             fi
         fi
-    done
+    fi
 
-    # 每5秒检查一次
+    if [ "${LEIGOD_ENABLE_UPDATER:-0}" = "1" ]; then
+        if ! is_process_running acc_upgrade_monitor "-r upgrade"; then
+            log_message "WARNING: starting unverified upstream updater"
+            start_updater
+        fi
+    elif [ "$updater_notice_written" -eq 0 ]; then
+        log_message "Automatic updater disabled; use the verified installer"
+        updater_notice_written=1
+    fi
+
+    truncate_oversized_daemon_log
     sleep 5
 done

--- a/packages/build-deb.sh
+++ b/packages/build-deb.sh
@@ -1,41 +1,61 @@
 #!/bin/sh
-set -e
+set -eu
 
-REPO_DIR="$(CDPATH= cd -P "$(dirname "$0")/.." && pwd)"
-BUILD_DIR="/tmp/opencode/leigod-plugin-build"
-OUTPUT="$REPO_DIR/packages/leigod-plugin_1.2.2.15_amd64.deb"
+umask 077
 
-rm -rf "$BUILD_DIR"
-mkdir -p "$BUILD_DIR/DEBIAN" "$BUILD_DIR/opt/leigod/config" "$BUILD_DIR/usr/share/doc/leigod-plugin"
+REPO_DIR=$(CDPATH= cd -P "$(dirname "$0")/.." && pwd)
+# shellcheck disable=SC1091
+. "$REPO_DIR/release.env"
 
-# Download both assets, verify pinned SHA-256 values, then install atomically.
-LEIGOD_CHECKSUM_FILE=${LEIGOD_CHECKSUM_FILE:-$REPO_DIR/checksums.sha256} \
+CHECKSUM_FILE=${LEIGOD_CHECKSUM_FILE:-$REPO_DIR/checksums.sha256}
+BUILD_DIR=$(mktemp -d "${TMPDIR:-/tmp}/leigod-plugin-deb.XXXXXX")
+OUTPUT=$REPO_DIR/packages/leigod-plugin_${PACKAGE_VERSION}_amd64.deb
+OUTPUT_TMP=$OUTPUT.tmp.$$
+
+cleanup() {
+    rm -rf "$BUILD_DIR"
+    rm -f "$OUTPUT_TMP"
+}
+trap cleanup 0
+trap 'exit 1' HUP INT TERM
+
+command -v dpkg-deb >/dev/null 2>&1 || {
+    echo "[ERROR] dpkg-deb is required" >&2
+    exit 1
+}
+
+install -d -m 0755 \
+    "$BUILD_DIR/DEBIAN" \
+    "$BUILD_DIR/lib/systemd/system" \
+    "$BUILD_DIR/opt/leigod/config" \
+    "$BUILD_DIR/usr/share/doc/leigod-plugin"
+
+LEIGOD_CHECKSUM_FILE=$CHECKSUM_FILE \
     sh "$REPO_DIR/scripts/fetch-assets.sh" "$BUILD_DIR/opt/leigod"
 
-# Copy files
-cp "$REPO_DIR/opt/leigod/steamdeck_acc_monitor.sh" "$BUILD_DIR/opt/leigod/"
-cp "$REPO_DIR/opt/leigod/leigod_uninstall.sh" "$BUILD_DIR/opt/leigod/"
-cp "$REPO_DIR/opt/leigod/fake_os-release" "$BUILD_DIR/opt/leigod/"
-cp "$REPO_DIR/opt/leigod/fake_product_name" "$BUILD_DIR/opt/leigod/"
-cp "$REPO_DIR/opt/leigod/config/acc_version.ini" "$BUILD_DIR/opt/leigod/config/"
-cp "$REPO_DIR/opt/leigod/config/new_upgrade_conf.json" "$BUILD_DIR/opt/leigod/config/"
-cp "$REPO_DIR/opt/leigod/config/accelerator.ini" "$BUILD_DIR/opt/leigod/config/"
-cp "$REPO_DIR/checksums.sha256" "$BUILD_DIR/usr/share/doc/leigod-plugin/"
-touch "$BUILD_DIR/opt/leigod/config/accelerator"
+install -m 0755 "$REPO_DIR/opt/leigod/steamdeck_acc_monitor.sh" "$BUILD_DIR/opt/leigod/"
+install -m 0755 "$REPO_DIR/opt/leigod/leigod_uninstall.sh" "$BUILD_DIR/opt/leigod/"
+install -m 0755 "$REPO_DIR/scripts/device-mac.sh" "$BUILD_DIR/opt/leigod/"
+install -m 0644 "$REPO_DIR/opt/leigod/fake_os-release" "$BUILD_DIR/opt/leigod/"
+install -m 0644 "$REPO_DIR/opt/leigod/fake_product_name" "$BUILD_DIR/opt/leigod/"
+install -m 0644 "$REPO_DIR/opt/leigod/config/acc_version.ini" "$BUILD_DIR/opt/leigod/config/"
+install -m 0644 "$REPO_DIR/opt/leigod/config/new_upgrade_conf.json" "$BUILD_DIR/opt/leigod/config/"
+install -m 0644 "$REPO_DIR/opt/leigod/config/accelerator.ini" "$BUILD_DIR/opt/leigod/config/"
+: > "$BUILD_DIR/opt/leigod/config/accelerator"
+chmod 0644 "$BUILD_DIR/opt/leigod/config/accelerator"
 
-# Debian control files
-cp "$REPO_DIR/debian/control" "$BUILD_DIR/DEBIAN/"
-cp "$REPO_DIR/debian/preinst" "$BUILD_DIR/DEBIAN/"
-cp "$REPO_DIR/debian/postinst" "$BUILD_DIR/DEBIAN/"
-cp "$REPO_DIR/debian/prerm" "$BUILD_DIR/DEBIAN/"
-cp "$REPO_DIR/debian/postrm" "$BUILD_DIR/DEBIAN/"
+install -m 0644 "$REPO_DIR/systemd/leigod_plugin.service" "$BUILD_DIR/lib/systemd/system/"
+install -m 0644 "$CHECKSUM_FILE" "$BUILD_DIR/usr/share/doc/leigod-plugin/checksums.sha256"
+install -m 0644 "$REPO_DIR/LICENSE" "$BUILD_DIR/usr/share/doc/leigod-plugin/copyright"
+install -m 0644 "$REPO_DIR/THIRD_PARTY_NOTICES.md" "$BUILD_DIR/usr/share/doc/leigod-plugin/"
 
-# Permissions
-chmod 755 "$BUILD_DIR/DEBIAN/preinst" "$BUILD_DIR/DEBIAN/postinst"
-chmod 755 "$BUILD_DIR/DEBIAN/prerm" "$BUILD_DIR/DEBIAN/postrm"
-chmod 755 "$BUILD_DIR/opt/leigod/acc-gw.router.amd64" "$BUILD_DIR/opt/leigod/acc_upgrade_monitor"
-chmod 755 "$BUILD_DIR/opt/leigod/steamdeck_acc_monitor.sh" "$BUILD_DIR/opt/leigod/leigod_uninstall.sh"
+for control_file in control preinst postinst prerm postrm; do
+    install -m 0755 "$REPO_DIR/debian/$control_file" "$BUILD_DIR/DEBIAN/$control_file"
+done
+chmod 0644 "$BUILD_DIR/DEBIAN/control"
 
-fakeroot dpkg-deb --build "$BUILD_DIR" "$OUTPUT"
-rm -rf "$BUILD_DIR"
-echo "Built: $OUTPUT"
+export SOURCE_DATE_EPOCH TZ=UTC LC_ALL=C
+find "$BUILD_DIR" -exec touch -h -d "@$SOURCE_DATE_EPOCH" {} +
+dpkg-deb --root-owner-group --build "$BUILD_DIR" "$OUTPUT_TMP"
+mv -f "$OUTPUT_TMP" "$OUTPUT"
+echo "Built reproducibly: $OUTPUT"

--- a/packages/build-tar.sh
+++ b/packages/build-tar.sh
@@ -1,38 +1,59 @@
 #!/bin/sh
-set -e
+set -eu
 
-REPO_DIR="$(CDPATH= cd -P "$(dirname "$0")/.." && pwd)"
-OUTPUT="$REPO_DIR/packages/leigod-plugin_1.2.2.15_amd64.tar.gz"
-TMPDIR="/tmp/opencode/leigod-plugin-tar"
-PACKAGE_ROOT="$TMPDIR/leigod-plugin-1.2.2.15"
+umask 077
 
-rm -rf "$TMPDIR"
-mkdir -p "$PACKAGE_ROOT/opt/leigod/config" "$PACKAGE_ROOT/scripts"
+REPO_DIR=$(CDPATH= cd -P "$(dirname "$0")/.." && pwd)
+# shellcheck disable=SC1091
+. "$REPO_DIR/release.env"
 
-# Download both assets, verify pinned SHA-256 values, then install atomically.
-LEIGOD_CHECKSUM_FILE=${LEIGOD_CHECKSUM_FILE:-$REPO_DIR/checksums.sha256} \
+CHECKSUM_FILE=${LEIGOD_CHECKSUM_FILE:-$REPO_DIR/checksums.sha256}
+BUILD_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/leigod-plugin-tar.XXXXXX")
+PACKAGE_NAME=leigod-plugin-$PACKAGE_VERSION
+PACKAGE_ROOT=$BUILD_ROOT/$PACKAGE_NAME
+OUTPUT=$REPO_DIR/packages/leigod-plugin_${PACKAGE_VERSION}_amd64.tar.gz
+OUTPUT_TMP=$OUTPUT.tmp.$$
+
+cleanup() {
+    rm -rf "$BUILD_ROOT"
+    rm -f "$OUTPUT_TMP"
+}
+trap cleanup 0
+trap 'exit 1' HUP INT TERM
+
+install -d -m 0755 \
+    "$PACKAGE_ROOT/opt/leigod/config" \
+    "$PACKAGE_ROOT/scripts" \
+    "$PACKAGE_ROOT/systemd"
+
+LEIGOD_CHECKSUM_FILE=$CHECKSUM_FILE \
     sh "$REPO_DIR/scripts/fetch-assets.sh" "$PACKAGE_ROOT/opt/leigod"
 
-# Copy files
-cp "$REPO_DIR/opt/leigod/steamdeck_acc_monitor.sh" "$PACKAGE_ROOT/opt/leigod/"
-cp "$REPO_DIR/opt/leigod/leigod_uninstall.sh" "$PACKAGE_ROOT/opt/leigod/"
-cp "$REPO_DIR/opt/leigod/fake_os-release" "$PACKAGE_ROOT/opt/leigod/"
-cp "$REPO_DIR/opt/leigod/fake_product_name" "$PACKAGE_ROOT/opt/leigod/"
-cp "$REPO_DIR/opt/leigod/config/acc_version.ini" "$PACKAGE_ROOT/opt/leigod/config/"
-cp "$REPO_DIR/opt/leigod/config/new_upgrade_conf.json" "$PACKAGE_ROOT/opt/leigod/config/"
-cp "$REPO_DIR/opt/leigod/config/accelerator.ini" "$PACKAGE_ROOT/opt/leigod/config/"
-touch "$PACKAGE_ROOT/opt/leigod/config/accelerator"
-cp "$REPO_DIR/install.sh" "$PACKAGE_ROOT/"
-cp "$REPO_DIR/uninstall.sh" "$PACKAGE_ROOT/"
-cp "$REPO_DIR/checksums.sha256" "$PACKAGE_ROOT/"
-cp "$REPO_DIR/scripts/fetch-assets.sh" "$PACKAGE_ROOT/scripts/"
+install -m 0755 "$REPO_DIR/opt/leigod/steamdeck_acc_monitor.sh" "$PACKAGE_ROOT/opt/leigod/"
+install -m 0755 "$REPO_DIR/opt/leigod/leigod_uninstall.sh" "$PACKAGE_ROOT/opt/leigod/"
+install -m 0755 "$REPO_DIR/scripts/device-mac.sh" "$PACKAGE_ROOT/scripts/"
+install -m 0755 "$REPO_DIR/scripts/fetch-assets.sh" "$PACKAGE_ROOT/scripts/"
+install -m 0644 "$REPO_DIR/opt/leigod/fake_os-release" "$PACKAGE_ROOT/opt/leigod/"
+install -m 0644 "$REPO_DIR/opt/leigod/fake_product_name" "$PACKAGE_ROOT/opt/leigod/"
+install -m 0644 "$REPO_DIR/opt/leigod/config/acc_version.ini" "$PACKAGE_ROOT/opt/leigod/config/"
+install -m 0644 "$REPO_DIR/opt/leigod/config/new_upgrade_conf.json" "$PACKAGE_ROOT/opt/leigod/config/"
+install -m 0644 "$REPO_DIR/opt/leigod/config/accelerator.ini" "$PACKAGE_ROOT/opt/leigod/config/"
+: > "$PACKAGE_ROOT/opt/leigod/config/accelerator"
+chmod 0644 "$PACKAGE_ROOT/opt/leigod/config/accelerator"
 
-# Permissions
-chmod 755 "$PACKAGE_ROOT/install.sh" "$PACKAGE_ROOT/uninstall.sh"
-chmod 755 "$PACKAGE_ROOT/scripts/fetch-assets.sh"
-chmod 755 "$PACKAGE_ROOT/opt/leigod/acc-gw.router.amd64" "$PACKAGE_ROOT/opt/leigod/acc_upgrade_monitor"
-chmod 755 "$PACKAGE_ROOT/opt/leigod/steamdeck_acc_monitor.sh" "$PACKAGE_ROOT/opt/leigod/leigod_uninstall.sh"
+install -m 0755 "$REPO_DIR/install.sh" "$PACKAGE_ROOT/"
+install -m 0755 "$REPO_DIR/uninstall.sh" "$PACKAGE_ROOT/"
+install -m 0644 "$CHECKSUM_FILE" "$PACKAGE_ROOT/checksums.sha256"
+install -m 0644 "$REPO_DIR/release.env" "$PACKAGE_ROOT/"
+install -m 0644 "$REPO_DIR/systemd/leigod_plugin.service" "$PACKAGE_ROOT/systemd/"
+install -m 0644 "$REPO_DIR/README.md" "$PACKAGE_ROOT/"
+install -m 0644 "$REPO_DIR/LICENSE" "$PACKAGE_ROOT/"
+install -m 0644 "$REPO_DIR/THIRD_PARTY_NOTICES.md" "$PACKAGE_ROOT/"
 
-cd "$TMPDIR" && tar czf "$OUTPUT" "leigod-plugin-1.2.2.15/"
-rm -rf "$TMPDIR"
-echo "Built: $OUTPUT"
+export SOURCE_DATE_EPOCH TZ=UTC LC_ALL=C
+find "$PACKAGE_ROOT" -exec touch -h -d "@$SOURCE_DATE_EPOCH" {} +
+tar --sort=name --format=gnu --owner=0 --group=0 --numeric-owner \
+    --mtime="@$SOURCE_DATE_EPOCH" -C "$BUILD_ROOT" -cf - "$PACKAGE_NAME" \
+    | gzip -n > "$OUTPUT_TMP"
+mv -f "$OUTPUT_TMP" "$OUTPUT"
+echo "Built reproducibly: $OUTPUT"

--- a/release.env
+++ b/release.env
@@ -1,0 +1,4 @@
+UPSTREAM_VERSION=1.2.2.15
+PACKAGE_VERSION=1.2.2.15-1
+# Fixed timestamp used by package builders for reproducible archives.
+SOURCE_DATE_EPOCH=1788522452

--- a/scripts/device-mac.sh
+++ b/scripts/device-mac.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+set -eu
+
+umask 077
+
+STATE_DIR=${LEIGOD_STATE_DIR:-/var/lib/leigod}
+MAC_FILE=${LEIGOD_DEVICE_MAC_FILE:-$STATE_DIR/device-mac}
+MACHINE_ID_FILE=${LEIGOD_MACHINE_ID_FILE:-/etc/machine-id}
+
+die() {
+    echo "[ERROR] $*" >&2
+    exit 1
+}
+
+valid_mac() {
+    printf '%s\n' "$1" | grep -Eq '^[0-9A-Fa-f]{2}(:[0-9A-Fa-f]{2}){5}$'
+}
+
+hash_seed() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 | awk '{print $1}'
+    else
+        die "sha256sum or shasum is required"
+    fi
+}
+
+generate_mac() {
+    [ -s "$MACHINE_ID_FILE" ] || die "Machine ID is missing: $MACHINE_ID_FILE"
+    machine_id=$(tr -d ' \t\r\n' < "$MACHINE_ID_FILE")
+    [ -n "$machine_id" ] || die "Machine ID is empty: $MACHINE_ID_FILE"
+    suffix=$(printf 'leigod-device:%s\n' "$machine_id" | hash_seed | cut -c1-10)
+    printf '02:%s:%s:%s:%s:%s\n' \
+        "$(printf '%s' "$suffix" | cut -c1-2)" \
+        "$(printf '%s' "$suffix" | cut -c3-4)" \
+        "$(printf '%s' "$suffix" | cut -c5-6)" \
+        "$(printf '%s' "$suffix" | cut -c7-8)" \
+        "$(printf '%s' "$suffix" | cut -c9-10)"
+}
+
+mkdir -p "$STATE_DIR"
+chmod 0700 "$STATE_DIR"
+
+if [ -e "$MAC_FILE" ] && [ ! -f "$MAC_FILE" ]; then
+    die "Device MAC path is not a regular file: $MAC_FILE"
+fi
+
+if [ -s "$MAC_FILE" ]; then
+    device_mac=$(tr 'A-F' 'a-f' < "$MAC_FILE" | tr -d ' \t\r\n')
+    valid_mac "$device_mac" || die "Invalid persisted device MAC: $MAC_FILE"
+    printf '%s\n' "$device_mac"
+    exit 0
+fi
+
+device_mac=$(generate_mac)
+valid_mac "$device_mac" || die "Failed to generate a valid device MAC"
+tmp_file=$(mktemp "$STATE_DIR/.device-mac.XXXXXX") \
+    || die "Unable to create device MAC temporary file"
+trap 'rm -f "$tmp_file"' 0 HUP INT TERM
+printf '%s\n' "$device_mac" > "$tmp_file"
+chmod 0600 "$tmp_file"
+mv -f "$tmp_file" "$MAC_FILE"
+tmp_file=
+trap - 0 HUP INT TERM
+printf '%s\n' "$device_mac"

--- a/scripts/fetch-assets.sh
+++ b/scripts/fetch-assets.sh
@@ -102,9 +102,12 @@ fetch_and_verify "acc-gw.router.amd64" "acc-gw.router.amd64" "$WORK_DIR/acc-gw.r
 fetch_and_verify "ipdatacloud_country.xdb" "config/ipdatacloud_country.xdb" "$WORK_DIR/ipdatacloud_country.xdb"
 
 mkdir -p "$DEST_ROOT/config"
-ACC_STAGE=$DEST_ROOT/.acc-gw.router.amd64.new.$$
-UPGRADE_STAGE=$DEST_ROOT/.acc_upgrade_monitor.new.$$
-XDB_STAGE=$DEST_ROOT/config/.ipdatacloud_country.xdb.new.$$
+ACC_STAGE=$(mktemp "$DEST_ROOT/.acc-gw.router.amd64.XXXXXX") \
+    || die "Failed to create gateway staging file"
+UPGRADE_STAGE=$(mktemp "$DEST_ROOT/.acc_upgrade_monitor.XXXXXX") \
+    || die "Failed to create updater staging file"
+XDB_STAGE=$(mktemp "$DEST_ROOT/config/.ipdatacloud_country.xdb.XXXXXX") \
+    || die "Failed to create database staging file"
 
 cp "$WORK_DIR/acc-gw.router.amd64" "$ACC_STAGE"
 chmod 0755 "$ACC_STAGE"

--- a/systemd/leigod_plugin.service
+++ b/systemd/leigod_plugin.service
@@ -2,14 +2,53 @@
 Description=Leigod Plugin Service
 Wants=network-online.target
 After=network.target network-online.target
+StartLimitIntervalSec=60
+StartLimitBurst=5
 
 [Service]
+Type=simple
+WorkingDirectory=/opt/leigod
 ExecStart=/opt/leigod/steamdeck_acc_monitor.sh
 KillMode=control-group
-Restart=always
+KillSignal=SIGTERM
+TimeoutStopSec=15
+Restart=on-failure
 RestartSec=3
+
+# Private, lifecycle-managed paths. The device identity persists in
+# /var/lib/leigod while the atomic monitor lock lives in /run/leigod.
+RuntimeDirectory=leigod
+RuntimeDirectoryMode=0700
+StateDirectory=leigod
+StateDirectoryMode=0700
+PrivateTmp=true
+UMask=0077
+
+# The closed-source daemon needs network administration for TUN, routes,
+# iptables and ipset. Remove every unrelated root capability.
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW
+NoNewPrivileges=true
+DevicePolicy=closed
+DeviceAllow=/dev/net/tun rw
+
+ProtectSystem=strict
+ReadWritePaths=/opt/leigod/config
+ProtectHome=read-only
+ProtectControlGroups=true
+ProtectKernelLogs=true
+ProtectClock=true
+ProtectHostname=true
+PrivateMounts=true
+LockPersonality=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+RestrictNamespaces=true
+RemoveIPC=true
+SystemCallArchitectures=native
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6 AF_NETLINK
+
 BindReadOnlyPaths=/opt/leigod/fake_product_name:/sys/class/dmi/id/product_name
 BindReadOnlyPaths=/opt/leigod/fake_os-release:/etc/os-release
 
 [Install]
-WantedBy=default.target
+WantedBy=multi-user.target

--- a/tests/test-device-mac.sh
+++ b/tests/test-device-mac.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+set -eu
+
+REPO_DIR=$(CDPATH= cd -P "$(dirname "$0")/.." && pwd)
+TEST_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/leigod-mac-test.XXXXXX")
+trap 'rm -rf "$TEST_ROOT"' 0 HUP INT TERM
+
+MACHINE_ID=$TEST_ROOT/machine-id
+STATE_DIR=$TEST_ROOT/state
+printf '%s\n' 0123456789abcdef0123456789abcdef > "$MACHINE_ID"
+
+get_mac() {
+    LEIGOD_STATE_DIR=$STATE_DIR LEIGOD_MACHINE_ID_FILE=$MACHINE_ID \
+        sh "$REPO_DIR/scripts/device-mac.sh"
+}
+
+first=$(get_mac)
+second=$(get_mac)
+[ "$first" = "$second" ] || {
+    echo "device MAC changed between invocations" >&2
+    exit 1
+}
+printf '%s\n' "$first" | grep -Eq '^02(:[0-9a-f]{2}){5}$'
+[ "$(stat -c '%a' "$STATE_DIR")" = 700 ]
+[ "$(stat -c '%a' "$STATE_DIR/device-mac")" = 600 ]
+
+rm -f "$STATE_DIR/device-mac"
+[ "$(get_mac)" = "$first" ] || {
+    echo "machine-id derivation is not deterministic" >&2
+    exit 1
+}
+
+printf '%s\n' fedcba9876543210fedcba9876543210 > "$MACHINE_ID"
+rm -f "$STATE_DIR/device-mac"
+[ "$(get_mac)" != "$first" ] || {
+    echo "different machine IDs produced the same MAC" >&2
+    exit 1
+}
+
+printf '%s\n' invalid > "$STATE_DIR/device-mac"
+if get_mac >/dev/null 2>&1; then
+    echo "invalid persisted MAC was accepted" >&2
+    exit 1
+fi
+
+printf '%s\n' '02:aa:bb:cc:dd:ee' > "$STATE_DIR/device-mac"
+[ "$(get_mac)" = '02:aa:bb:cc:dd:ee' ]
+echo "device-mac tests passed"

--- a/tests/test-policy.sh
+++ b/tests/test-policy.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+set -eu
+
+REPO_DIR=$(CDPATH= cd -P "$(dirname "$0")/.." && pwd)
+cd "$REPO_DIR"
+
+grep -q 'CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW' systemd/leigod_plugin.service
+grep -q 'NoNewPrivileges=true' systemd/leigod_plugin.service
+grep -q 'PrivateTmp=true' systemd/leigod_plugin.service
+grep -q 'RuntimeDirectory=leigod' systemd/leigod_plugin.service
+grep -q 'StateDirectory=leigod' systemd/leigod_plugin.service
+grep -q 'Restart=on-failure' systemd/leigod_plugin.service
+grep -q 'MAX_DAEMON_LOG_BYTES=.*52428800' opt/leigod/steamdeck_acc_monitor.sh
+grep -q '/var/lib/leigod/device-mac' README.md
+grep -q 'Bazzite' README.md
+grep -q 'THIRD_PARTY_NOTICES.md' README.md
+
+if grep -RE '^[[:space:]]*iptables[[:space:]].*-F' \
+    install.sh uninstall.sh opt scripts debian; then
+    echo "unsafe iptables flush command found" >&2
+    exit 1
+fi
+
+if grep -q '/sys/class/net/${iface}/address' opt/leigod/steamdeck_acc_monitor.sh; then
+    echo "monitor still copies a transient physical MAC" >&2
+    exit 1
+fi
+
+package_version=$(sed -n 's/^PACKAGE_VERSION=//p' release.env)
+upstream_version=$(sed -n 's/^UPSTREAM_VERSION=//p' release.env)
+grep -q "^Version: $package_version$" debian/control
+grep -q "^version=$upstream_version$" opt/leigod/config/acc_version.ini
+echo "policy tests passed"

--- a/tests/test-reproducible-build.sh
+++ b/tests/test-reproducible-build.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+set -eu
+
+REPO_DIR=$(CDPATH= cd -P "$(dirname "$0")/.." && pwd)
+# shellcheck disable=SC1091
+. "$REPO_DIR/release.env"
+TEST_ROOT=$(mktemp -d "${TMPDIR:-/tmp}/leigod-build-test.XXXXXX")
+TAR_OUTPUT=$REPO_DIR/packages/leigod-plugin_${PACKAGE_VERSION}_amd64.tar.gz
+DEB_OUTPUT=$REPO_DIR/packages/leigod-plugin_${PACKAGE_VERSION}_amd64.deb
+trap 'rm -rf "$TEST_ROOT"; rm -f "$TAR_OUTPUT" "$DEB_OUTPUT"' 0 HUP INT TERM
+
+FIXTURES=$TEST_ROOT/fixtures
+mkdir -p "$FIXTURES/config"
+printf 'fixture gateway\n' > "$FIXTURES/acc-gw.router.amd64"
+printf 'fixture database\n' > "$FIXTURES/config/ipdatacloud_country.xdb"
+acc_hash=$(sha256sum "$FIXTURES/acc-gw.router.amd64" | awk '{print $1}')
+xdb_hash=$(sha256sum "$FIXTURES/config/ipdatacloud_country.xdb" | awk '{print $1}')
+printf '%s  %s\n%s  %s\n' \
+    "$acc_hash" acc-gw.router.amd64 \
+    "$xdb_hash" ipdatacloud_country.xdb \
+    > "$TEST_ROOT/checksums.sha256"
+
+LEIGOD_ASSET_SOURCE_DIR=$FIXTURES LEIGOD_CHECKSUM_FILE=$TEST_ROOT/checksums.sha256 \
+    sh "$REPO_DIR/packages/build-tar.sh"
+cp "$TAR_OUTPUT" "$TEST_ROOT/first.tar.gz"
+sleep 1
+LEIGOD_ASSET_SOURCE_DIR=$FIXTURES LEIGOD_CHECKSUM_FILE=$TEST_ROOT/checksums.sha256 \
+    sh "$REPO_DIR/packages/build-tar.sh"
+cmp "$TEST_ROOT/first.tar.gz" "$TAR_OUTPUT"
+tar -tzf "$TAR_OUTPUT" | grep -q "leigod-plugin-$PACKAGE_VERSION/THIRD_PARTY_NOTICES.md"
+
+if command -v dpkg-deb >/dev/null 2>&1; then
+    LEIGOD_ASSET_SOURCE_DIR=$FIXTURES LEIGOD_CHECKSUM_FILE=$TEST_ROOT/checksums.sha256 \
+        sh "$REPO_DIR/packages/build-deb.sh"
+    cp "$DEB_OUTPUT" "$TEST_ROOT/first.deb"
+    sleep 1
+    LEIGOD_ASSET_SOURCE_DIR=$FIXTURES LEIGOD_CHECKSUM_FILE=$TEST_ROOT/checksums.sha256 \
+        sh "$REPO_DIR/packages/build-deb.sh"
+    cmp "$TEST_ROOT/first.deb" "$DEB_OUTPUT"
+    dpkg-deb --info "$DEB_OUTPUT" >/dev/null
+fi
+echo "reproducible-build tests passed"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,37 +1,15 @@
 #!/bin/sh
-set -e
+set -eu
 
-BASE="/opt/leigod"
-SERVICE_NAME="leigod_plugin.service"
-SERVICE_FILE="/etc/systemd/system/$SERVICE_NAME"
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCRIPT_DIR=$(CDPATH= cd -P "$(dirname "$0")" && pwd)
 
-RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
-info()  { printf "${GREEN}[INFO]${NC} %s\n" "$*"; }
-warn()  { printf "${YELLOW}[WARN]${NC} %s\n" "$*"; }
-error() { printf "${RED}[ERROR]${NC} %s\n" "$*"; exit 1; }
-
-if [ "$(id -u)" -ne 0 ]; then error "Please run as root (sudo ./uninstall.sh)"; fi
-
-echo ""; echo "Leigod Plugin Uninstaller"; echo "========================="
-printf "${YELLOW}Remove Leigod Plugin? [y/N] ${NC}"
-read -r confirm
-if [ "$confirm" != "y" ] && [ "$confirm" != "Y" ]; then info "Cancelled."; exit 0; fi
-
-systemctl stop "$SERVICE_NAME" 2>/dev/null || true
-systemctl disable "$SERVICE_NAME" 2>/dev/null || true
-rm -f "$SERVICE_FILE"
-systemctl daemon-reload 2>/dev/null || true
-
-for proc in acc-gw.router.amd64 acc_upgrade_monitor steamdeck_acc_monitor.sh; do
-    pids=$(pidof "$proc" 2>/dev/null || true)
-    [ -n "$pids" ] && kill -9 $pids 2>/dev/null || true
-done
-
-rm -rf "$BASE" /tmp/acc
-
-if [ -L /home/leigod ] && [ "$(readlink /home/leigod)" = "$BASE" ]; then
-    rm -f /home/leigod
+if [ -x "$SCRIPT_DIR/opt/leigod/leigod_uninstall.sh" ]; then
+    exec "$SCRIPT_DIR/opt/leigod/leigod_uninstall.sh" "$@"
 fi
 
-echo ""; echo "============================================"; echo " Leigod Plugin uninstalled."; echo "============================================"; echo ""
+if [ -x /opt/leigod/leigod_uninstall.sh ]; then
+    exec /opt/leigod/leigod_uninstall.sh "$@"
+fi
+
+echo "[ERROR] leigod_uninstall.sh was not found" >&2
+exit 1


### PR DESCRIPTION
## Summary

Follow-up hardening after #6, addressing the remaining P1/P2 audit findings.

### Stable device identity

- derive a locally administered unicast MAC from `/etc/machine-id`
- persist it at `/var/lib/leigod/device-mac` across service restarts and normal reinstalls
- stop copying NetworkManager's potentially randomized physical MAC
- retain an explicit warning for hosts whose real wireless interface is already named `wlan0`

Addresses the root cause documented in #1.

### Reliable install and service lifecycle

- stop an existing service before replacing assets and attempt recovery on installation failure
- require both the systemd unit and the acceleration daemon to become healthy before printing success
- apply the same health check to Debian package installation
- replace global PID killing with service-first, path-scoped cleanup
- make the monitor exit after repeated launch failures so systemd can report/rate-limit the fault
- keep the monitor lock in an atomic, mode-0700 runtime directory and clean it on exit
- isolate `/tmp/acc` with `PrivateTmp`; send monitor logs to journald and cap the daemon log at 50 MiB

### Service hardening

- restrict the root process to `CAP_NET_ADMIN` and `CAP_NET_RAW`
- allow only `/dev/net/tun`
- enable `NoNewPrivileges`, strict filesystem protection, namespace restrictions and managed runtime/state directories
- change unconditional restart to rate-limited `Restart=on-failure`

`systemd-analyze security --offline=yes` reports an exposure score of **4.3 / OK**.

### Support and release engineering

- support only mutable, systemd-based x86_64 hosts using apt-get, dnf, pacman or zypper
- reject Bazzite/Silverblue/Kinoite/CoreOS/bootc host installs before modification
- install and verify the complete runtime dependency set
- distinguish upstream version `1.2.2.15` from package revision `1.2.2.15-1`
- make TAR and DEB output reproducible with fixed timestamps, ordering and ownership
- add CI for shell syntax, ShellCheck errors, policy tests and reproducibility tests
- add a tag-driven, source-only Release workflow
- document the MIT/third-party licensing boundary and avoid automated redistribution of Leigod binaries

## Validation

- all shell files pass `dash -n` and `bash -n`
- `tests/test-device-mac.sh`
- `tests/test-fetch-assets.sh`
- `tests/test-policy.sh`
- `tests/test-reproducible-build.sh`
  - two TAR builds are byte-identical
  - two DEB builds are byte-identical
- systemd offline security analysis: `4.3 OK`

A real supported x86_64 Linux host test is still recommended before release because the proprietary daemon cannot be executed in the CI environment.
